### PR TITLE
Setup manual deployment workflow

### DIFF
--- a/.github/workflows/manual-deploy-setup.yml
+++ b/.github/workflows/manual-deploy-setup.yml
@@ -1,0 +1,21 @@
+name: Manual Deploy Setup
+on:
+  workflow_dispatch:
+
+jobs:
+  setup-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run secure deploy setup script
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          REPO: ${{ github.repository }}
+        run: |
+          chmod +x secure_setup_deploy_key.sh
+          ./secure_setup_deploy_key.sh

--- a/.github/workflows/manual-deploy-setup.yml
+++ b/.github/workflows/manual-deploy-setup.yml
@@ -6,7 +6,7 @@ jobs:
   setup-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Run secure deploy setup script

--- a/.github/workflows/notify-on-deploy-status.yml
+++ b/.github/workflows/notify-on-deploy-status.yml
@@ -1,0 +1,43 @@
+name: Notify on Deploy Status
+
+on:
+  workflow_run:
+    workflows:
+      - "Manual Deploy Setup"
+      - "Auto Deploy to Server"
+    types:
+      - completed
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check workflow status
+        if: ${{ github.event.workflow_run.conclusion != 'success' }}
+        run: |
+          echo "⚠️ Deployment failed!"
+          echo "Workflow: ${{ github.event.workflow_run.name }}"
+          echo "Run URL: ${{ github.event.workflow_run.html_url }}"
+          echo "Status: ${{ github.event.workflow_run.conclusion }}"
+
+      - name: Send email notification
+        if: always()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.MAIL_USER }}
+          password: ${{ secrets.MAIL_PASS }}
+          subject: >
+            ${{ github.event.workflow_run.name }} —
+            ${{ github.event.workflow_run.conclusion == 'success' && '✅ Success' || '❌ Failed' }}
+          to: ${{ secrets.NOTIFY_EMAIL }}
+          from: "Nursery System CI"
+          secure: true
+          body: |
+            Workflow: ${{ github.event.workflow_run.name }}
+            Repository: ${{ github.repository }}
+            Status: ${{ github.event.workflow_run.conclusion }}
+            Run URL: ${{ github.event.workflow_run.html_url }}
+            Triggered by: ${{ github.actor }}
+            Commit: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
Add GitHub Actions workflows to manually set up deploy keys and send email notifications on deployment status.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb7319db-4318-4a09-a076-0667c1010fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb7319db-4318-4a09-a076-0667c1010fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds workflows to manually set up deploy keys and send email notifications on deploy workflow completion.
> 
> - **CI / GitHub Actions**:
>   - **Manual Deploy Setup** (`.github/workflows/manual-deploy-setup.yml`):
>     - Adds `workflow_dispatch` job to run `secure_setup_deploy_key.sh` using `GH_TOKEN`, `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PORT`, and `REPO`.
>   - **Deploy Status Notifications** (`.github/workflows/notify-on-deploy-status.yml`):
>     - Triggers on completion of `Manual Deploy Setup` and `Auto Deploy to Server`.
>     - Logs failed runs and sends email via `dawidd6/action-send-mail@v3` (Gmail SMTP) using repo secrets (recipient `NOTIFY_EMAIL`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95adfd8121270ba058c2f7fac8a7043ccfb67a4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->